### PR TITLE
Connect witness finder to Perplexity API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,72 @@
-from fastapi import FastAPI, Request
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import re
+from typing import Any, Dict, List, Tuple
+
+from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+
+from openai import OpenAI
+from pydantic import BaseModel, Field, field_validator
 
 from app.config import settings
 from app.routers import health, issue_spotter
 from app.routers.witness_finder import router as witness_finder_router
 
 app = FastAPI(title="LAWAgent")
+
+logger = logging.getLogger("lawagent.ask_witness")
+
+_API_KEY = os.getenv("PERPLEXITY_API_KEY")
+_CLIENT: OpenAI | None = None
+if _API_KEY:
+    _CLIENT = OpenAI(api_key=_API_KEY, base_url="https://api.perplexity.ai")
+
+_CACHE_TTL_SECONDS = 600
+_REQUEST_CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+_RATE_LIMIT_WINDOW = 60.0
+_RATE_LIMIT_MAX = 5
+_RATE_LIMIT_BUCKET: Dict[str, List[float]] = {}
+
+
+class WitnessQuery(BaseModel):
+    sector: str = Field(..., min_length=1, max_length=200)
+    description: str = Field(..., min_length=1, max_length=1500)
+    name: str | None = Field(default=None, max_length=200)
+
+    @field_validator("sector", "description", "name", mode="before")
+    @classmethod
+    def _strip_and_cast(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @field_validator("sector", "description", mode="after")
+    @classmethod
+    def _ensure_not_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("Field is required.")
+        cleaned = "".join(ch if ch.isprintable() else " " for ch in value)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        if not cleaned:
+            raise ValueError("Field is required.")
+        return cleaned
+
+    @field_validator("name", mode="after")
+    @classmethod
+    def _escape_optional(cls, value: str | None) -> str | None:
+        if not value:
+            return None
+        cleaned = "".join(ch if ch.isprintable() else " " for ch in value)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned or None
 
 origins = ["http://localhost:8000", "http://127.0.0.1:8000", "*"]
 if settings.allowed_origins:
@@ -34,3 +93,159 @@ async def witness_finder_page(request: Request):
     if wants_html and "application/json" not in accept.split(",")[0]:
         return FileResponse("app/static/witness-finder.html")
     return JSONResponse({"service": "witness_finder", "hint": "Use /api/witness_finder/search for POST"})
+
+
+def _call_perplexity(query: WitnessQuery) -> Dict[str, Any]:
+    if not _CLIENT:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Perplexity API key is missing.")
+
+    prompt = (
+        "You are an AI legal research assistant who surfaces expert witness candidates. "
+        "Summarize key findings clearly and list notable experts with reliable sources."
+    )
+    user_message = (
+        f"Sector: {query.sector}\n"
+        f"Description: {query.description}\n"
+        f"Name hint: {query.name or 'None'}\n"
+        "Provide concise summary followed by expert witness candidates and their supporting sources."
+    )
+
+    start = time.perf_counter()
+    try:
+        response = _CLIENT.chat.completions.create(
+            model="sonar",
+            max_tokens=500,
+            temperature=0.7,
+            similarity_filter=0,
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": user_message},
+            ],
+        )
+    except Exception as exc:  # pragma: no cover - network failure
+        elapsed = time.perf_counter() - start
+        logger.error("Perplexity chat call failed after %.2fs: %s", elapsed, exc)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Unable to reach Perplexity API.") from exc
+
+    elapsed = time.perf_counter() - start
+    logger.info("Perplexity chat completed in %.2fs", elapsed)
+    payload = response.model_dump()
+    return payload
+
+
+def _format_perplexity_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    choices = payload.get("choices") if isinstance(payload, dict) else None
+    summary = ""
+    results: List[Dict[str, Any]] = []
+
+    if isinstance(choices, list) and choices:
+        message = choices[0] or {}
+        if isinstance(message, dict):
+            content = message.get("message") if "message" in message else message
+            if isinstance(content, dict):
+                summary = str(content.get("content") or "").strip()
+                citations_candidates = []
+                for key in ("citations", "references", "context", "sources"):
+                    value = content.get(key)
+                    if isinstance(value, list):
+                        citations_candidates.extend(value)
+            else:
+                summary = str(message.get("content") or "").strip()
+                citations_candidates = []
+        else:
+            citations_candidates = []
+    else:
+        citations_candidates = []
+
+    if not summary and isinstance(payload, dict):
+        summary = str(payload.get("summary") or "").strip()
+
+    additional_keys = ("citations", "references", "context", "results", "data", "sources")
+    for key in additional_keys:
+        value = payload.get(key) if isinstance(payload, dict) else None
+        if isinstance(value, list):
+            citations_candidates.extend(value)
+
+    seen_urls = set()
+    for item in citations_candidates:
+        if not isinstance(item, dict):
+            continue
+        url = str(
+            item.get("url")
+            or item.get("source")
+            or item.get("link")
+            or item.get("citation")
+            or ""
+        ).strip()
+        if not url or url in seen_urls:
+            continue
+        title = str(
+            item.get("title")
+            or item.get("name")
+            or item.get("headline")
+            or url
+        ).strip()
+        snippet = str(
+            item.get("snippet")
+            or item.get("text")
+            or item.get("summary")
+            or item.get("description")
+            or ""
+        ).strip()
+        result_entry: Dict[str, Any] = {"title": title or url, "url": url, "snippet": snippet}
+        similarity = item.get("similarity") or item.get("score") or item.get("similarity_score")
+        if isinstance(similarity, (int, float)):
+            result_entry["similarity"] = float(similarity)
+        results.append(result_entry)
+        seen_urls.add(url)
+
+    return {"summary": summary, "results": results}
+
+
+def _cache_key(query: WitnessQuery) -> str:
+    payload = query.model_dump()
+    return json.dumps(payload, sort_keys=True)
+
+
+def _rate_limited(identifier: str) -> bool:
+    now = time.time()
+    timestamps = _RATE_LIMIT_BUCKET.setdefault(identifier, [])
+    timestamps[:] = [ts for ts in timestamps if now - ts < _RATE_LIMIT_WINDOW]
+    if len(timestamps) >= _RATE_LIMIT_MAX:
+        return True
+    timestamps.append(now)
+    return False
+
+
+@app.post("/api/ask-witness")
+async def ask_witness(query: WitnessQuery, request: Request) -> Dict[str, Any]:
+    if _rate_limited((request.client.host if request.client else "anonymous")):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded. Try again shortly.")
+
+    cache_key = _cache_key(query)
+    cached = _REQUEST_CACHE.get(cache_key)
+    now = time.time()
+    if cached and now - cached[0] < _CACHE_TTL_SECONDS:
+        logger.info("Returning cached witness results for key %s", cache_key)
+        return cached[1]
+
+    start_time = time.perf_counter()
+    try:
+        payload = _call_perplexity(query)
+        formatted = _format_perplexity_response(payload)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        elapsed = time.perf_counter() - start_time
+        logger.error("Unexpected error after %.2fs: %s", elapsed, exc)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Unexpected server error.") from exc
+
+    elapsed = time.perf_counter() - start_time
+    logger.info("Witness search handled in %.2fs", elapsed)
+
+    if not formatted.get("summary"):
+        formatted["summary"] = ""
+    formatted.setdefault("results", [])
+
+    _REQUEST_CACHE[cache_key] = (now, formatted)
+    return formatted

--- a/app/static/witness-finder.html
+++ b/app/static/witness-finder.html
@@ -49,23 +49,23 @@
           </div>
           <form id="witnessFinderForm" class="card-body" novalidate>
             <div class="field-group">
-              <label for="industryInput">Industry / Sector <span aria-hidden="true">*</span></label>
+              <label for="sectorInput">Sector <span aria-hidden="true">*</span></label>
               <input
                 type="text"
-                id="industryInput"
-                name="industry"
+                id="sectorInput"
+                name="sector"
                 required
-                placeholder="e.g., Pharmaceuticals, Fintech, Energy"
+                placeholder="e.g., Healthcare, Financial Services, Energy"
               />
             </div>
             <div class="field-group">
-              <label for="descriptionInput">Description of need <span aria-hidden="true">*</span></label>
+              <label for="descriptionInput">Description <span aria-hidden="true">*</span></label>
               <textarea
                 id="descriptionInput"
                 name="description"
                 rows="6"
                 required
-                placeholder="Describe the dispute, product, or technical issues requiring testimony"
+                placeholder="Describe the legal matter or expertise needed"
               ></textarea>
             </div>
             <div class="field-group">
@@ -100,49 +100,12 @@
             <p class="results-status" id="wfResultsStatus" aria-live="polite">Awaiting search.</p>
           </div>
           <div class="card-body">
-            <section class="filters" aria-label="Result filters">
-              <div class="filter-group">
-                <label for="filterSimilarity">Min similarity</label>
-                <input type="range" id="filterSimilarity" min="0" max="100" value="0" />
-                <span class="filter-value" data-filter-display="similarity">0%</span>
-              </div>
-              <div class="filter-group">
-                <label for="filterExperience">Min years experience</label>
-                <input type="range" id="filterExperience" min="0" max="40" value="0" />
-                <span class="filter-value" data-filter-display="experience">0</span>
-              </div>
-              <div class="filter-group">
-                <label for="filterSector">Sector filter</label>
-                <input type="text" id="filterSector" placeholder="Any" />
-              </div>
-              <div class="filter-group">
-                <label for="filterLocation">Location filter</label>
-                <input type="text" id="filterLocation" placeholder="Any" />
-              </div>
-            </section>
-
+            <article class="witness-summary" id="wfSummary" hidden></article>
             <div id="wfResults" class="results-grid" aria-live="polite"></div>
-
             <div class="empty-state" id="wfEmpty" hidden>
-              <p>No candidates match the current filters. Adjust the sliders or run a new search.</p>
+              <p>No results found. Try refining your query.</p>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section class="container saved-section" aria-labelledby="wf-saved-heading">
-        <header class="saved-header">
-          <div>
-            <h2 id="wf-saved-heading">Saved witnesses</h2>
-            <p class="subtitle">Persisted locally for quick recall across sessions.</p>
-          </div>
-          <button class="btn ghost" id="wfToggleSaved" aria-expanded="false" aria-controls="wfSavedList">
-            Show saved
-          </button>
-        </header>
-        <div id="wfSavedList" class="saved-list" hidden aria-live="polite"></div>
-        <div class="empty-state" id="wfSavedEmpty" hidden>
-          <p>No saved witnesses yet. Save candidates to build your roster.</p>
         </div>
       </section>
     </main>
@@ -156,6 +119,174 @@
     <div class="toast-container" role="status" aria-live="polite"></div>
 
     <script src="assets/js/ui.js" defer></script>
-    <script src="assets/js/witness-finder.js" defer></script>
+    <script>
+      (function () {
+        const form = document.getElementById('witnessFinderForm');
+        const loading = document.getElementById('wfLoading');
+        const progressText = document.getElementById('wfProgress');
+        const etaText = document.getElementById('wfEta');
+        const progressBar = document.getElementById('wfProgressBar');
+        const statusEl = document.getElementById('wfResultsStatus');
+        const summaryEl = document.getElementById('wfSummary');
+        const resultsEl = document.getElementById('wfResults');
+        const emptyEl = document.getElementById('wfEmpty');
+        const errorEl = form.querySelector('.form-error');
+
+        let loadingInterval = null;
+
+        function updateStatus(message) {
+          if (statusEl) {
+            statusEl.textContent = message;
+          }
+        }
+
+        function resetResults() {
+          summaryEl.textContent = '';
+          summaryEl.hidden = true;
+          resultsEl.innerHTML = '';
+          emptyEl.hidden = true;
+        }
+
+        function startLoading() {
+          loading.hidden = false;
+          let progress = 0;
+          progressText.textContent = '0%';
+          etaText.textContent = '06';
+          progressBar.style.width = '0%';
+
+          loadingInterval = window.setInterval(() => {
+            progress = Math.min(progress + Math.random() * 12, 95);
+            progressText.textContent = `${Math.round(progress)}%`;
+            progressBar.style.width = `${Math.round(progress)}%`;
+            const eta = Math.max(1, Math.ceil((100 - progress) / 15)).toString().padStart(2, '0');
+            etaText.textContent = eta;
+          }, 400);
+        }
+
+        function stopLoading() {
+          if (loadingInterval) {
+            window.clearInterval(loadingInterval);
+            loadingInterval = null;
+          }
+          progressText.textContent = '100%';
+          progressBar.style.width = '100%';
+          etaText.textContent = '00';
+          window.setTimeout(() => {
+            loading.hidden = true;
+            progressBar.style.width = '0%';
+          }, 300);
+        }
+
+        async function fetchWitnesses(payload) {
+          const response = await fetch('/api/ask-witness', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            const detail = errorData.detail || 'Unable to fetch witness data.';
+            throw new Error(detail);
+          }
+
+          return response.json();
+        }
+
+        function renderSummary(summary) {
+          if (!summary) {
+            summaryEl.textContent = '';
+            summaryEl.hidden = true;
+            return;
+          }
+          summaryEl.textContent = summary;
+          summaryEl.hidden = false;
+        }
+
+        function renderResults(results) {
+          resultsEl.innerHTML = '';
+          if (!Array.isArray(results) || results.length === 0) {
+            emptyEl.hidden = false;
+            return;
+          }
+
+          emptyEl.hidden = true;
+          results.forEach((result) => {
+            const card = document.createElement('article');
+            card.className = 'witness-card';
+
+            const header = document.createElement('div');
+            header.className = 'witness-card-header';
+
+            const titleLink = document.createElement('a');
+            titleLink.className = 'nav-link';
+            titleLink.href = result.url || '#';
+            titleLink.target = '_blank';
+            titleLink.rel = 'noopener noreferrer';
+            titleLink.textContent = result.title || 'View source';
+            header.appendChild(titleLink);
+
+            if (typeof result.similarity === 'number' && !Number.isNaN(result.similarity)) {
+              const score = document.createElement('span');
+              score.className = 'witness-score';
+              score.textContent = `${result.similarity.toFixed(2)}`;
+              header.appendChild(score);
+            }
+
+            const snippet = document.createElement('p');
+            snippet.className = 'witness-summary';
+            snippet.textContent = result.snippet || 'No summary provided for this source.';
+
+            card.appendChild(header);
+            card.appendChild(snippet);
+            resultsEl.appendChild(card);
+          });
+        }
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          errorEl.hidden = true;
+          errorEl.textContent = '';
+
+          const formData = new FormData(form);
+          const sector = (formData.get('sector') || '').toString().trim();
+          const description = (formData.get('description') || '').toString().trim();
+          const name = (formData.get('name') || '').toString().trim();
+
+          if (!sector || !description) {
+            errorEl.textContent = 'Sector and description are required.';
+            errorEl.hidden = false;
+            return;
+          }
+
+          resetResults();
+          updateStatus('Querying Perplexity for expert witnesses…');
+          startLoading();
+
+          try {
+            const payload = { sector, description, name };
+            if (!name) {
+              delete payload.name;
+            }
+            const data = await fetchWitnesses(payload);
+            renderSummary(data.summary || '');
+            renderResults(data.results || []);
+            if (!data.summary && (!data.results || data.results.length === 0)) {
+              emptyEl.hidden = false;
+            }
+            updateStatus('Search complete.');
+          } catch (error) {
+            resetResults();
+            emptyEl.hidden = false;
+            updateStatus('No results found. Try refining your query.');
+            const message = error instanceof Error ? error.message : 'Unable to complete the request.';
+            errorEl.textContent = message;
+            errorEl.hidden = false;
+          } finally {
+            stopLoading();
+          }
+        });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated /api/ask-witness FastAPI route that validates input, rate limits, caches responses, and proxies to Perplexity's chat completions API
- parse Perplexity responses into summary/result payloads while logging timings and surfacing errors cleanly
- rebuild the witness finder page to submit queries to the new endpoint, show loading progress, and render summary/result cards using existing styling

## Testing
- not run (not requested)


