### PR TITLE
Add follow-up question support to Issue Spotter

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from openai import OpenAI
 from pydantic import BaseModel, Field, field_validator
 
 from app.config import settings
-from app.routers import health, issue_spotter
+from app.routers import followup, health, issue_spotter
 from app.routers.witness_finder import router as witness_finder_router
 
 app = FastAPI(title="LAWAgent")
@@ -81,6 +81,7 @@ app.add_middleware(
 )
 
 app.include_router(issue_spotter.router, prefix="/api/issue-spotter", tags=["Issue Spotter"])
+app.include_router(followup.router, prefix="/api/followup", tags=["Follow-up"])
 app.include_router(witness_finder_router)
 app.include_router(health.router, prefix="/api/health", tags=["Health"])
 app.mount("/", StaticFiles(directory="app/static", html=True), name="static")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import health, issue_spotter, witness_finder
+from . import followup, health, issue_spotter, witness_finder
 
-__all__ = ["issue_spotter", "health", "witness_finder"]
+__all__ = ["issue_spotter", "health", "witness_finder", "followup"]

--- a/app/routers/followup.py
+++ b/app/routers/followup.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from app.services.followup import answer_followup
+
+router = APIRouter()
+
+
+class FollowupRequest(BaseModel):
+    question: str = Field(...)
+    context: str = Field(...)
+
+    @field_validator("question", "context", mode="before")
+    @classmethod
+    def _strip(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        text = str(value).strip()
+        return text
+
+
+class FollowupResponse(BaseModel):
+    answer: str
+
+
+@router.post("", response_model=FollowupResponse)
+async def create_followup(request: FollowupRequest) -> FollowupResponse:
+    question = (request.question or "").strip()
+    context = (request.context or "").strip()
+
+    if not question:
+        raise HTTPException(status_code=400, detail="Follow-up question is required.")
+    if not context:
+        raise HTTPException(status_code=400, detail="Analysis context is required.")
+
+    try:
+        answer = await answer_followup(question, context)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail="Unable to generate a follow-up answer.") from exc
+
+    return FollowupResponse(answer=answer)

--- a/app/services/followup.py
+++ b/app/services/followup.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    AsyncOpenAI,
+    AuthenticationError,
+    BadRequestError,
+    OpenAIError,
+    RateLimitError,
+)
+
+from app.config import settings
+
+logger = logging.getLogger("lawagent.followup")
+
+_MODEL = settings.openai_model
+_client = AsyncOpenAI(api_key=settings.openai_api_key)
+
+_SYSTEM_PROMPT = (
+    "You are LAWAgent's conversational follow-up assistant. "
+    "Use the supplied issue spotter analysis to answer questions clearly, "
+    "empathetically, and with practical legal insight. Reference the context when useful."
+)
+
+
+async def answer_followup(question: str, context: str) -> str:
+    clean_question = (question or "").strip()
+    clean_context = (context or "").strip()
+
+    if not clean_question:
+        raise ValueError("Follow-up question is required.")
+    if not clean_context:
+        raise ValueError("Analysis context is required for follow-up answers.")
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                "Here is the prior issue spotter analysis for context:\n"
+                f"{clean_context}\n\n"
+                "Answer the user's follow-up question in a conversational, explanatory tone:\n"
+                f"{clean_question}"
+            ),
+        },
+    ]
+
+    try:
+        completion = await _client.chat.completions.create(
+            model=_MODEL,
+            messages=messages,
+            temperature=0.45,
+            timeout=45,
+        )
+    except AuthenticationError as exc:  # pragma: no cover - network error handling
+        logger.exception("Authentication failed during follow-up call.")
+        raise ValueError("Authentication with the AI provider failed. Check your API key.") from exc
+    except RateLimitError as exc:  # pragma: no cover - network error handling
+        logger.exception("Rate limit hit while requesting follow-up answer.")
+        raise ValueError("Rate limit reached. Please wait a moment and try again.") from exc
+    except APIConnectionError as exc:  # pragma: no cover - network error handling
+        logger.exception("Network error while requesting follow-up answer.")
+        raise ValueError("Network error: unable to reach the AI service.") from exc
+    except APIStatusError as exc:  # pragma: no cover - network error handling
+        status = getattr(exc, "status_code", None)
+        logger.exception("OpenAI returned an error status for follow-up (status=%s).", status)
+        if status and 500 <= status < 600:
+            raise ValueError("AI provider encountered a server error. Try again later.") from exc
+        raise ValueError("AI request failed. Verify the model and inputs.") from exc
+    except BadRequestError as exc:  # pragma: no cover - network error handling
+        logger.exception("Bad request while requesting follow-up answer.")
+        raise ValueError("The follow-up request was invalid or too large.") from exc
+    except OpenAIError as exc:  # pragma: no cover - network error handling
+        logger.exception("Unexpected OpenAI error during follow-up answer.")
+        raise ValueError("The AI service is temporarily unavailable. Try again later.") from exc
+
+    content = completion.choices[0].message.content if completion.choices else ""
+    answer = (content or "").strip()
+    if not answer:
+        raise ValueError("The AI did not return a follow-up answer.")
+
+    return answer

--- a/app/static/assets/css/main.css
+++ b/app/static/assets/css/main.css
@@ -244,6 +244,19 @@ button {
   box-shadow: 0 22px 40px rgba(124, 92, 255, 0.32);
 }
 
+.btn.secondary {
+  border-color: rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.18);
+  box-shadow: 0 10px 22px rgba(124, 92, 255, 0.18);
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(124, 92, 255, 0.28);
+  box-shadow: 0 16px 30px rgba(124, 92, 255, 0.26);
+}
+
 .btn.ghost {
   border-color: rgba(124, 92, 255, 0.45);
   background: rgba(124, 92, 255, 0.15);
@@ -358,6 +371,56 @@ input[type="text"]:hover,
 input[type="text"]:focus {
   border-color: rgba(124, 92, 255, 0.45);
   background: rgba(15, 20, 34, 0.9);
+}
+
+.followup-section {
+  margin-top: 2rem;
+  padding-top: 1.6rem;
+  border-top: 1px solid rgba(124, 92, 255, 0.24);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.followup-section .field-group {
+  margin-bottom: 0;
+}
+
+.followup-section textarea {
+  min-height: 130px;
+}
+
+.followup-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.followup-conversation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.followup-exchange {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(124, 92, 255, 0.12);
+  border: 1px solid rgba(124, 92, 255, 0.22);
+  box-shadow: 0 12px 30px rgba(8, 10, 26, 0.25);
+}
+
+.followup-exchange .followup-question {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.followup-exchange .followup-answer {
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  line-height: 1.6;
 }
 
 input[type="file"] {

--- a/app/static/issue-spotter.html
+++ b/app/static/issue-spotter.html
@@ -147,6 +147,24 @@
                 <pre id="jsonOutput" class="panel-output" tabindex="0"></pre>
               </section>
             </div>
+
+            <div class="followup-section" aria-live="polite">
+              <div class="field-group">
+                <label for="followupInput">Follow-up Questions (optional)</label>
+                <textarea
+                  id="followupInput"
+                  name="followup"
+                  rows="5"
+                  placeholder="Ask for clarifications, more detail, or next steps based on the analysis."
+                ></textarea>
+                <p class="field-help">LAWAgent will answer conversationally using the latest analysis as context.</p>
+              </div>
+              <div class="followup-actions">
+                <button class="btn secondary" type="button" id="followupBtn">Ask Follow-up</button>
+              </div>
+              <p id="followupError" class="form-error" role="alert" aria-live="polite" hidden></p>
+              <div id="followupConversation" class="followup-conversation" aria-live="polite"></div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a follow-up textarea, trigger button, and response thread to the Issue Spotter results panel
- submit follow-up questions with the latest analysis context from the frontend and render conversational replies
- expose a new `/api/followup` FastAPI endpoint backed by OpenAI with a friendlier system prompt

## Testing
- pytest

------
