### PR TITLE
Implement contextual follow-up chat workflow

### DIFF
--- a/app/routers/followup.py
+++ b/app/routers/followup.py
@@ -6,11 +6,26 @@ from app.services.followup import answer_followup
 router = APIRouter()
 
 
+class FollowupMessage(BaseModel):
+    role: str = Field(...)
+    content: str = Field(...)
+
+    @field_validator("role", "content", mode="before")
+    @classmethod
+    def _strip(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return str(value).strip()
+
+
 class FollowupRequest(BaseModel):
     question: str = Field(...)
     context: str = Field(...)
+    instruction: str | None = Field(default=None)
+    document: str | None = Field(default=None)
+    history: list[FollowupMessage] = Field(default_factory=list)
 
-    @field_validator("question", "context", mode="before")
+    @field_validator("question", "context", "instruction", "document", mode="before")
     @classmethod
     def _strip(cls, value: str | None) -> str | None:
         if value is None:
@@ -27,6 +42,12 @@ class FollowupResponse(BaseModel):
 async def create_followup(request: FollowupRequest) -> FollowupResponse:
     question = (request.question or "").strip()
     context = (request.context or "").strip()
+    instruction = (request.instruction or "").strip()
+    document = (request.document or "").strip()
+    history = [
+        {"role": (message.role or "").strip(), "content": (message.content or "").strip()}
+        for message in request.history
+    ]
 
     if not question:
         raise HTTPException(status_code=400, detail="Follow-up question is required.")
@@ -34,7 +55,13 @@ async def create_followup(request: FollowupRequest) -> FollowupResponse:
         raise HTTPException(status_code=400, detail="Analysis context is required.")
 
     try:
-        answer = await answer_followup(question, context)
+        answer = await answer_followup(
+            question=question,
+            context=context,
+            instruction=instruction,
+            document=document,
+            history=history,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive

--- a/app/static/assets/css/main.css
+++ b/app/static/assets/css/main.css
@@ -379,7 +379,7 @@ input[type="text"]:focus {
   border-top: 1px solid rgba(124, 92, 255, 0.24);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .followup-section .field-group {
@@ -395,32 +395,65 @@ input[type="text"]:focus {
   justify-content: flex-end;
 }
 
-.followup-conversation {
+.followup-chat {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
-.followup-exchange {
+.followup-chat:empty {
+  display: none;
+}
+
+.followup-chat .chat-message {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  padding: 1rem 1.1rem;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
   border-radius: var(--radius-sm);
-  background: rgba(124, 92, 255, 0.12);
-  border: 1px solid rgba(124, 92, 255, 0.22);
   box-shadow: 0 12px 30px rgba(8, 10, 26, 0.25);
+  border: 1px solid transparent;
+  max-width: min(100%, 34rem);
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
-.followup-exchange .followup-question {
-  font-weight: 600;
+.followup-chat .chat-message.user {
+  align-self: flex-end;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.9), rgba(94, 120, 255, 0.85));
+  border-color: rgba(124, 92, 255, 0.45);
+  color: #f8f9ff;
+}
+
+.followup-chat .chat-message.assistant {
+  align-self: flex-start;
+  background: rgba(124, 92, 255, 0.12);
+  border-color: rgba(124, 92, 255, 0.22);
   color: var(--text-strong);
 }
 
-.followup-exchange .followup-answer {
-  color: var(--text-muted);
+.followup-chat .chat-message.error {
+  align-self: center;
+  background: rgba(210, 82, 92, 0.16);
+  border-color: rgba(210, 82, 92, 0.35);
+  color: #ffd9df;
+  text-align: center;
+  max-width: 100%;
+}
+
+.followup-chat .chat-sender {
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.followup-chat .chat-content {
   white-space: pre-wrap;
-  line-height: 1.6;
+  word-break: break-word;
 }
 
 input[type="file"] {

--- a/app/static/assets/js/issue-spotter.js
+++ b/app/static/assets/js/issue-spotter.js
@@ -17,14 +17,28 @@
     const citationsOutput = document.getElementById('citationsOutput');
     const jsonOutput = document.getElementById('jsonOutput');
 
-    const followupInput = document.getElementById('followupInput');
-    const followupBtn = document.getElementById('followupBtn');
+    const followupInput = document.getElementById('followup-textarea');
+    const followupBtn = document.getElementById('ask-followup-btn');
     const followupError = document.getElementById('followupError');
-    const followupConversation = document.getElementById('followupConversation');
+    const followupConversation = document.getElementById('followup-chat');
+
+    const sessionSupported = supportsSessionStorage();
+    const FOLLOWUP_STATE_KEY = 'lawagent:issue-spotter:followup-state';
+    const THEME_STATE_KEY = 'lawagent:theme';
+    const FOLLOWUP_TRANSCRIPT_LIMIT = 60;
 
     let latestAnalysisData = null;
+    let latestInstructionText = '';
+    let latestStyleSelection = '';
+    let latestDocumentSource = '';
+    let followupHistory = [];
+    let followupTranscript = [];
+    let pendingAnalysisMeta = null;
 
     const tabGroupId = 'results';
+
+    restoreThemePreference();
+    restoreFollowupState();
 
     if (followupBtn) {
       followupBtn.addEventListener('click', handleFollowupRequest);
@@ -53,6 +67,14 @@
         return;
       }
 
+      pendingAnalysisMeta = {
+        instructions: clampText(instructionsValue, 4000),
+        style: styleValue || '',
+        document: hasFile
+          ? describeUploadedFile(fileInput.files[0])
+          : clampText(textValue, 8000),
+      };
+
       setLoading(true);
       updateStatus('Analyzing…');
 
@@ -78,6 +100,7 @@
         console.error(error);
         updateStatus('Analysis failed.');
         showError(error.message || 'Unable to process the request.');
+        pendingAnalysisMeta = null;
       } finally {
         setLoading(false);
       }
@@ -122,6 +145,21 @@
         citations: Array.isArray(citations) ? citations : [],
         raw_json: rawJson ?? null,
       };
+
+      if (pendingAnalysisMeta) {
+        latestInstructionText = pendingAnalysisMeta.instructions || '';
+        latestStyleSelection = pendingAnalysisMeta.style || '';
+        latestDocumentSource = pendingAnalysisMeta.document || '';
+        pendingAnalysisMeta = null;
+      } else {
+        latestInstructionText = clampText(instructionsInput.value.trim(), 4000);
+        latestStyleSelection = styleSelect.value || '';
+        const textValue = textInput.value.trim();
+        if (textValue) {
+          latestDocumentSource = clampText(textValue, 8000);
+        }
+      }
+
       resetFollowupConversation();
       clearFollowupError();
       summaryOutput.textContent = (summary && summary.trim()) || 'No summary provided.';
@@ -141,6 +179,8 @@
       } else {
         jsonOutput.textContent = 'JSON output was disabled for this request.';
       }
+
+      persistFollowupState();
     }
 
     function renderFindings(items) {
@@ -219,19 +259,27 @@
         return;
       }
 
+      const context = buildFollowupContext(latestAnalysisData);
+      if (!context) {
+        showFollowupError('Analysis context is unavailable. Please rerun the analysis.');
+        return;
+      }
+
+      addChatMessage({ role: 'user', content: question });
+      followupInput.value = '';
+      followupInput.focus();
+
       setFollowupLoading(true);
 
+      const payload = {
+        question,
+        context,
+        instruction: buildInstructionContext(),
+        document: clampText(latestDocumentSource || '', 8000),
+        history: buildHistoryPayload(),
+      };
+
       try {
-        const payload = {
-          question,
-          context: buildFollowupContext(latestAnalysisData),
-        };
-
-        if (!payload.context.trim()) {
-          showFollowupError('Analysis context is unavailable. Please rerun the analysis.');
-          return;
-        }
-
         const response = await fetch('/api/followup', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -240,45 +288,144 @@
 
         if (!response.ok) {
           const errorPayload = await safeJson(response);
-          const detail = errorPayload?.detail || 'Unable to process the follow-up question.';
-          throw new Error(detail);
+          const detail = errorPayload?.detail;
+          throw new Error(detail || 'Unable to process the follow-up question.');
         }
 
         const data = await response.json();
         const answer = typeof data.answer === 'string' ? data.answer.trim() : '';
 
         if (!answer) {
-          showFollowupError('The AI did not return an answer. Please try again.');
-          return;
+          throw new Error('The AI did not return an answer.');
         }
 
-        appendFollowupExchange(question, answer);
-        followupInput.value = '';
-        followupInput.focus();
+        addChatMessage({ role: 'assistant', content: answer });
+        pushHistoryMessage('user', question);
+        pushHistoryMessage('assistant', answer);
+        persistFollowupState();
       } catch (error) {
         console.error(error);
-        showFollowupError(error.message || 'Unable to process the follow-up question.');
+        addChatMessage({ role: 'error', content: 'Network error, please try again.' });
+        persistFollowupState();
       } finally {
         setFollowupLoading(false);
       }
     }
 
-    function appendFollowupExchange(question, answer) {
+    function buildHistoryPayload() {
+      if (!followupHistory.length) {
+        return [];
+      }
+      return followupHistory.map((message) => ({ role: message.role, content: message.content }));
+    }
+
+    function pushHistoryMessage(role, content) {
+      const sanitized = sanitizeHistoryMessage({ role, content });
+      if (!sanitized) return;
+      followupHistory.push(sanitized);
+      if (followupHistory.length > FOLLOWUP_TRANSCRIPT_LIMIT * 2) {
+        followupHistory = followupHistory.slice(-FOLLOWUP_TRANSCRIPT_LIMIT * 2);
+      }
+    }
+
+    function sanitizeHistoryMessage(message) {
+      if (!message || typeof message.content !== 'string') {
+        return null;
+      }
+      const content = message.content.trim();
+      if (!content) return null;
+      let role = typeof message.role === 'string' ? message.role.toLowerCase() : 'user';
+      if (role !== 'assistant' && role !== 'user') {
+        role = role === 'system' ? 'assistant' : 'user';
+      }
+      return { role, content };
+    }
+
+    function addChatMessage(message, options = {}) {
+      const normalized = normalizeChatMessage(message);
+      if (!normalized) return null;
+
+      followupTranscript.push(normalized);
+
+      if (followupTranscript.length > FOLLOWUP_TRANSCRIPT_LIMIT) {
+        followupTranscript = followupTranscript.slice(-FOLLOWUP_TRANSCRIPT_LIMIT);
+        renderFollowupTranscript();
+      } else if (followupConversation) {
+        const bubble = createChatBubble(normalized);
+        if (bubble) {
+          followupConversation.appendChild(bubble);
+        }
+      }
+
+      scrollFollowupConversation();
+
+      if (options.persist !== false) {
+        persistFollowupState();
+      }
+
+      return normalized;
+    }
+
+    function normalizeChatMessage(message) {
+      if (!message || typeof message.content !== 'string') return null;
+      const content = message.content.trim();
+      if (!content) return null;
+      let role = typeof message.role === 'string' ? message.role.toLowerCase() : 'assistant';
+      if (role !== 'user' && role !== 'assistant' && role !== 'error') {
+        role = role === 'system' ? 'assistant' : 'user';
+      }
+      return { role, content };
+    }
+
+    function renderFollowupTranscript() {
       if (!followupConversation) return;
-      const exchange = document.createElement('div');
-      exchange.className = 'followup-exchange';
+      followupConversation.innerHTML = '';
+      followupTranscript.forEach((message) => {
+        const bubble = createChatBubble(message);
+        if (bubble) {
+          followupConversation.appendChild(bubble);
+        }
+      });
+      scrollFollowupConversation();
+    }
 
-      const questionEl = document.createElement('div');
-      questionEl.className = 'followup-question';
-      questionEl.textContent = question;
-      exchange.appendChild(questionEl);
+    function createChatBubble(message) {
+      if (!message) return null;
+      const bubble = document.createElement('div');
+      bubble.className = `chat-message ${message.role}`;
 
-      const answerEl = document.createElement('div');
-      answerEl.className = 'followup-answer';
-      answerEl.textContent = answer;
-      exchange.appendChild(answerEl);
+      const sender = document.createElement('div');
+      sender.className = 'chat-sender';
+      if (message.role === 'assistant') {
+        sender.textContent = 'LAWAgent';
+      } else if (message.role === 'user') {
+        sender.textContent = 'You';
+      } else {
+        sender.textContent = 'System';
+      }
 
-      followupConversation.appendChild(exchange);
+      const content = document.createElement('div');
+      content.className = 'chat-content';
+      content.textContent = message.content;
+
+      bubble.appendChild(sender);
+      bubble.appendChild(content);
+
+      return bubble;
+    }
+
+    function scrollFollowupConversation() {
+      if (!followupConversation) return;
+      followupConversation.scrollTop = followupConversation.scrollHeight;
+    }
+
+    function resetFollowupConversation() {
+      followupTranscript = [];
+      followupHistory = [];
+      if (followupConversation) {
+        followupConversation.innerHTML = '';
+      }
+      persistFollowupState();
     }
 
     function updateStatus(message) {
@@ -300,6 +447,7 @@
     function setFollowupLoading(isLoading) {
       if (!followupBtn) return;
       followupBtn.disabled = isLoading;
+      followupBtn.classList.toggle('loading', isLoading);
       if (isLoading) {
         followupBtn.setAttribute('aria-busy', 'true');
       } else {
@@ -331,27 +479,244 @@
       followupError.hidden = true;
     }
 
-    function resetFollowupConversation() {
-      if (!followupConversation) return;
-      followupConversation.innerHTML = '';
+    function buildFollowupContext(result) {
+      if (!result) return '';
+      const sections = [];
+
+      if (result.summary) {
+        sections.push(`Summary:\n${result.summary}`);
+      }
+
+      if (Array.isArray(result.findings) && result.findings.length) {
+        const findingsText = result.findings
+          .map((item, index) => {
+            const parts = [];
+            const heading = item.issue || `Finding ${index + 1}`;
+            parts.push(`${index + 1}. ${heading}`);
+            if (item.risk) {
+              parts.push(`Risk: ${item.risk}`);
+            }
+            if (item.suggestion) {
+              parts.push(`Suggestion: ${item.suggestion}`);
+            }
+            if (item.span && (item.span.page || item.span.start || item.span.end)) {
+              const spanParts = [];
+              if (item.span.page) spanParts.push(`Page ${item.span.page}`);
+              if (item.span.start || item.span.end) {
+                const start = item.span.start ?? '?';
+                const end = item.span.end ?? '?';
+                spanParts.push(`Chars ${start}-${end}`);
+              }
+              parts.push(`Span: ${spanParts.join(' • ')}`);
+            }
+            return parts.join('\n');
+          })
+          .join('\n\n');
+        sections.push(`Findings:\n${findingsText}`);
+      }
+
+      if (Array.isArray(result.citations) && result.citations.length) {
+        const citationsText = result.citations
+          .map((item, index) => {
+            const label = item.page ? `Page ${item.page}` : `Citation ${index + 1}`;
+            const snippet = item.snippet || '';
+            return `${label}: ${snippet}`.trim();
+          })
+          .join('\n');
+        if (citationsText) {
+          sections.push(`Citations:\n${citationsText}`);
+        }
+      }
+
+      if (result.raw_json) {
+        try {
+          const raw =
+            typeof result.raw_json === 'string'
+              ? result.raw_json
+              : JSON.stringify(result.raw_json, null, 2);
+          if (raw) {
+            sections.push(`Raw JSON:\n${raw}`);
+          }
+        } catch (error) {
+          console.error('Failed to serialize raw analysis JSON', error);
+        }
+      }
+
+      const context = sections.join('\n\n').trim();
+      return clampText(context, 10000);
     }
 
-    function buildFollowupContext(result) {
-      try {
-        return JSON.stringify(
-          {
-            summary: result.summary || '',
-            findings: Array.isArray(result.findings) ? result.findings : [],
-            citations: Array.isArray(result.citations) ? result.citations : [],
-            raw_json: result.raw_json ?? null,
-          },
-          null,
-          2
-        );
-      } catch (error) {
-        console.error('Failed to build follow-up context', error);
-        return '';
+    function buildInstructionContext() {
+      const segments = [];
+      if (latestInstructionText) {
+        segments.push(latestInstructionText);
       }
+      if (latestStyleSelection) {
+        segments.push(`Preferred analysis style: ${latestStyleSelection}`);
+      }
+      return clampText(segments.join('\n\n'), 4000);
+    }
+
+    function persistFollowupState() {
+      if (!sessionSupported) return;
+      const state = {
+        transcript: followupTranscript,
+        history: followupHistory,
+        latestAnalysis: latestAnalysisData,
+        instruction: latestInstructionText,
+        style: latestStyleSelection,
+        document: latestDocumentSource,
+      };
+      try {
+        sessionStorage.setItem(FOLLOWUP_STATE_KEY, JSON.stringify(state));
+      } catch (error) {
+        console.warn('Failed to persist follow-up state', error);
+      }
+    }
+
+    function restoreFollowupState() {
+      if (!sessionSupported) return;
+      let stored;
+      try {
+        const raw = sessionStorage.getItem(FOLLOWUP_STATE_KEY);
+        if (!raw) return;
+        stored = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Failed to restore follow-up state', error);
+        return;
+      }
+
+      if (stored.latestAnalysis && typeof stored.latestAnalysis === 'object') {
+        latestAnalysisData = stored.latestAnalysis;
+      }
+      if (typeof stored.instruction === 'string') {
+        latestInstructionText = stored.instruction;
+      }
+      if (typeof stored.style === 'string') {
+        latestStyleSelection = stored.style;
+      }
+      if (typeof stored.document === 'string') {
+        latestDocumentSource = stored.document;
+      }
+
+      followupHistory = Array.isArray(stored.history)
+        ? stored.history.map(sanitizeHistoryMessage).filter(Boolean)
+        : [];
+      followupTranscript = Array.isArray(stored.transcript)
+        ? stored.transcript.map(normalizeChatMessage).filter(Boolean)
+        : [];
+
+      renderFollowupTranscript();
+    }
+
+    function clampText(value, maxLength) {
+      const text = typeof value === 'string' ? value.trim() : '';
+      if (!maxLength || text.length <= maxLength) {
+        return text;
+      }
+      return `${text.slice(0, maxLength - 1)}…`;
+    }
+
+    function describeUploadedFile(file) {
+      if (!file) return 'Uploaded file';
+      const parts = [`Uploaded file: ${file.name || 'document'}`];
+      if (file.type) {
+        parts.push(`Type: ${file.type}`);
+      }
+      if (file.size) {
+        const kb = Math.round(file.size / 1024);
+        parts.push(`Size: ${kb}KB`);
+      }
+      return parts.join(' · ');
+    }
+
+    function supportsSessionStorage() {
+      try {
+        const key = '__lawagent_ss__';
+        window.sessionStorage.setItem(key, '1');
+        window.sessionStorage.removeItem(key);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    function restoreThemePreference() {
+      observeThemeChanges();
+      if (!sessionSupported) return;
+      try {
+        const storedTheme = sessionStorage.getItem(THEME_STATE_KEY);
+        if (storedTheme) {
+          applyTheme(storedTheme);
+        }
+      } catch (error) {
+        console.warn('Failed to restore theme preference', error);
+      }
+      persistThemePreference();
+    }
+
+    function observeThemeChanges() {
+      const persist = () => {
+        persistThemePreference();
+      };
+
+      const observer = new MutationObserver(persist);
+      const targets = [document.documentElement, document.body];
+      targets.forEach((target) => {
+        if (!target) return;
+        observer.observe(target, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+      });
+
+      document.addEventListener('lawagent:theme-change', persist);
+    }
+
+    function persistThemePreference() {
+      if (!sessionSupported) return;
+      const theme = detectTheme();
+      if (!theme) return;
+      try {
+        sessionStorage.setItem(THEME_STATE_KEY, theme);
+      } catch (error) {
+        console.warn('Failed to persist theme preference', error);
+      }
+    }
+
+    function detectTheme() {
+      const html = document.documentElement;
+      const body = document.body;
+      const attr =
+        (html && (html.dataset.theme || html.getAttribute('data-theme'))) ||
+        (body && (body.dataset.theme || body.getAttribute('data-theme')));
+      if (attr) {
+        return attr.toLowerCase();
+      }
+
+      const classes = [
+        ...(html ? Array.from(html.classList || []) : []),
+        ...(body ? Array.from(body.classList || []) : []),
+      ];
+
+      if (classes.some((name) => /light/i.test(name))) {
+        return 'light';
+      }
+      if (classes.some((name) => /dark/i.test(name))) {
+        return 'dark';
+      }
+      return '';
+    }
+
+    function applyTheme(theme) {
+      if (!theme) return;
+      const normalized = theme.toLowerCase();
+      if (document.documentElement) {
+        document.documentElement.setAttribute('data-theme', normalized);
+        document.documentElement.dataset.theme = normalized;
+      }
+      if (document.body) {
+        document.body.setAttribute('data-theme', normalized);
+        document.body.dataset.theme = normalized;
+      }
+    }
     }
 
     async function safeJson(response) {

--- a/app/static/issue-spotter.html
+++ b/app/static/issue-spotter.html
@@ -149,21 +149,24 @@
             </div>
 
             <div class="followup-section" aria-live="polite">
-              <div class="field-group">
-                <label for="followupInput">Follow-up Questions (optional)</label>
+              <div class="field-group followup-field">
+                <label for="followup-textarea">Follow-up Questions (optional)</label>
                 <textarea
-                  id="followupInput"
+                  id="followup-textarea"
                   name="followup"
                   rows="5"
                   placeholder="Ask for clarifications, more detail, or next steps based on the analysis."
                 ></textarea>
                 <p class="field-help">LAWAgent will answer conversationally using the latest analysis as context.</p>
+                <p id="followupError" class="form-error" role="alert" aria-live="polite" hidden></p>
               </div>
               <div class="followup-actions">
-                <button class="btn secondary" type="button" id="followupBtn">Ask Follow-up</button>
+                <button class="btn primary" type="button" id="ask-followup-btn">
+                  <span class="btn-label">Ask Follow-up</span>
+                  <span class="btn-progress" aria-hidden="true"></span>
+                </button>
               </div>
-              <p id="followupError" class="form-error" role="alert" aria-live="polite" hidden></p>
-              <div id="followupConversation" class="followup-conversation" aria-live="polite"></div>
+              <div id="followup-chat" class="followup-chat" aria-live="polite"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- implement a richer follow-up API that passes instruction, document, and chat history to the model and returns conversational answers
- rebuild the Issue Spotter follow-up UI as a chat-style experience with shared button styling, loading state, and sessionStorage persistence
- capture theme and chat transcript between visits while refreshing follow-up context after each analysis

## Testing
- python -m compileall app

------
